### PR TITLE
Update com.feaneron.Boatswain.json -> GNOME 43 is no longer supported!

### DIFF
--- a/com.feaneron.Boatswain.json
+++ b/com.feaneron.Boatswain.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.feaneron.Boatswain",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "boatswain",
     "finish-args": [


### PR DESCRIPTION
The GNOME 43 runtime is no longer supported as of September 20, 2023.