### PR TITLE
Update runtime to 49

### DIFF
--- a/com.feaneron.Boatswain.json
+++ b/com.feaneron.Boatswain.json
@@ -26,22 +26,6 @@
     ],
     "modules": [
         {
-            "name": "hidapi",
-            "buildsystem": "autotools",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/libusb/hidapi.git",
-                    "tag": "hidapi-0.15.0",
-                    "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^hidapi-([\\d.]+)$"
-                    },
-                    "commit": "d6b2a974608dec3b76fb1e36c189f22b9cf3650c"
-                }
-            ]
-        },
-        {
             "name": "gusb",
             "buildsystem": "meson",
             "config-opts": [

--- a/com.feaneron.Boatswain.json
+++ b/com.feaneron.Boatswain.json
@@ -63,26 +63,6 @@
             ]
         },
         {
-            "name": "gjs",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Dinstalled_tests=false",
-                "-Dskip_dbus_tests=true",
-                "-Dskip_gtk_tests=true"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gjs/1.87/gjs-1.87.1.tar.xz",
-                    "sha256": "95f7a73acc5b2dbe643a6851ba5b4001230a75e1e859afc9a81fbf4861b899cf",
-                    "x-checker-data": {
-                        "type": "gnome",
-                        "name": "gjs"
-                    }
-                }
-            ]
-        },
-        {
             "name": "libpeas",
             "buildsystem": "meson",
             "cleanup": [

--- a/com.feaneron.Boatswain.json
+++ b/com.feaneron.Boatswain.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.feaneron.Boatswain",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "boatswain",
     "finish-args": [
@@ -25,7 +25,6 @@
         "*.a"
     ],
     "modules": [
-        "shared-modules/libusb/libusb.json",
         {
             "name": "hidapi",
             "buildsystem": "autotools",
@@ -33,12 +32,12 @@
                 {
                     "type": "git",
                     "url": "https://github.com/libusb/hidapi.git",
-                    "tag": "hidapi-0.14.0",
+                    "tag": "hidapi-0.15.0",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^hidapi-([\\d.]+)$"
                     },
-                    "commit": "d3013f0af3f4029d82872c1a9487ea461a56dee4"
+                    "commit": "d6b2a974608dec3b76fb1e36c189f22b9cf3650c"
                 }
             ]
         },
@@ -74,8 +73,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gjs/1.84/gjs-1.84.1.tar.xz",
-                    "sha256": "44796b91318dbbe221a13909f00fd872ef92f38c68603e0e3574e46bc6bac32c",
+                    "url": "https://download.gnome.org/sources/gjs/1.87/gjs-1.87.1.tar.xz",
+                    "sha256": "95f7a73acc5b2dbe643a6851ba5b4001230a75e1e859afc9a81fbf4861b899cf",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "gjs"
@@ -97,8 +96,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libpeas/2.0/libpeas-2.0.7.tar.xz",
-                    "sha256": "1e9a9d69761d2109eff5b7c11d8c96b4867ccfaca2b921eded49401192769ec9",
+                    "url": "https://download.gnome.org/sources/libpeas/2.2/libpeas-2.2.0.tar.xz",
+                    "sha256": "c2887233f084a69fabfc7fa0140d410491863d7050afb28677f9a553b2580ad9",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "libpeas"
@@ -122,33 +121,6 @@
                     "type": "git",
                     "url": "https://github.com/flatpak/libportal.git",
                     "tag": "0.9.1"
-                }
-            ]
-        },
-        {
-            "name" : "gdk-pixbuf",
-            "buildsystem" : "meson",
-            "config-opts" : [
-                "-Dgtk_doc=false",
-                "-Dman=false",
-                "-Dothers=enabled"
-            ],
-            "cleanup" : [
-                "/bin/*"
-            ],
-            "post-install" : [
-                "rm /app/lib/libgdk_pixbuf-2.0.so*",
-                "rm /app/lib/pkgconfig/gdk-pixbuf-2.0.pc"
-            ],
-            "sources" : [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gdk-pixbuf/2.42/gdk-pixbuf-2.42.12.tar.xz",
-                    "sha256": "b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7",
-                    "x-checker-data": {
-                        "type": "gnome",
-                        "name": "gdk-pixbuf"
-                    }
                 }
             ]
         },


### PR DESCRIPTION
- Update runtime to 49
- Drop **libusb** module, freedesktop runtime provides it
- Drop **gdk-pixbuf** module, GNOME runtime provides it
- Drop **gjs** module, GNOME runtime provides it

Fixes: https://github.com/flathub/com.feaneron.Boatswain/issues/57