### PR TITLE
Improve cleanup commands

### DIFF
--- a/com.feaneron.Boatswain.json
+++ b/com.feaneron.Boatswain.json
@@ -15,12 +15,10 @@
     ],
     "cleanup": [
         "/include",
+        "/lib/girepository-1.0",
         "/lib/pkgconfig",
-        "/man",
         "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
+        "/share/gir-1.0",
         "*.la",
         "*.a"
     ],


### PR DESCRIPTION
- Improve cleanup commands to reduce the Flatpak size
- Drop ineffective cleanup commands

```
76K    ./lib/girepository-1.0
684K   ./share/gir-1.0
```

**Please don't forget to test before merging. I don't have a Streamdeck device to test these changes. 
Some apps might require  /lib/girepository-1.0 related files.**